### PR TITLE
Bump PHP to 8.3, improve container startup, and remove redundant Render build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # PHPとComposerが使えるベースのイメージ
-FROM php:8.2-fpm
+FROM php:8.3-fpm
 
 # 必要なパッケージをインストール
 RUN apt-get update && apt-get install -y \
@@ -35,4 +35,4 @@ EXPOSE 10000
 RUN php artisan config:clear && php artisan route:clear && php artisan view:clear
 
 # マイグレーションしてからサーバー起動
-CMD php artisan migrate --force && php artisan serve --host=0.0.0.0 --port=10000
+CMD sh -c "php artisan migrate --force && exec php artisan serve --host=0.0.0.0 --port=10000"

--- a/render.yaml
+++ b/render.yaml
@@ -14,8 +14,3 @@ services:
         value: base64:fx/EOA3Oli6Z3l3NwKtZc1R8VImWylMjfbELClDaUr8=
       - key: APP_URL
         value: https://score-manager-backend.onrender.com/
-
-buildCommand: |
-  composer install
-  php artisan config:clear
-  php artisan config:cache


### PR DESCRIPTION
### Motivation
- Upgrade the runtime to `php:8.3-fpm` and ensure the container handles signals correctly while consolidating build steps into the image for cleaner deployments.

### Description
- Updated the base image from `php:8.2-fpm` to `php:8.3-fpm` in `Dockerfile`.
- Changed the container start command to `sh -c "php artisan migrate --force && exec php artisan serve --host=0.0.0.0 --port=10000"` to ensure proper `exec`/signal handling.
- Removed the `buildCommand` that ran `composer install` and config cache from `render.yaml` because dependency installation is handled inside the `Dockerfile`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f57268d88330b934ee114e3f4c1f)