### PR TITLE
Upgrade PHP to 8.3, improve Docker CMD handling, add CI/CD documentation, and update Render config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # PHPとComposerが使えるベースのイメージ
-FROM php:8.2-fpm
+FROM php:8.3-fpm
 
 # 必要なパッケージをインストール
 RUN apt-get update && apt-get install -y \
@@ -35,4 +35,4 @@ EXPOSE 10000
 RUN php artisan config:clear && php artisan route:clear && php artisan view:clear
 
 # マイグレーションしてからサーバー起動
-CMD php artisan migrate --force && php artisan serve --host=0.0.0.0 --port=10000
+CMD sh -c "php artisan migrate --force && exec php artisan serve --host=0.0.0.0 --port=10000"

--- a/document/ci-cd-process.md
+++ b/document/ci-cd-process.md
@@ -1,0 +1,63 @@
+# CI/CDプロセス
+
+このリポジトリのCI/CDは、**GitHub Actions（CI）** と **Render（CD）** を使って構成されています。
+
+## 1. CI（GitHub Actions）
+
+ワークフローは `.github/workflows/backend-ci.yml` で管理されています。
+
+### トリガー
+- `main` ブランチへの `push`
+- `main` ブランチ向けの `pull_request`
+
+### 実行内容
+1. リポジトリをチェックアウト
+2. PHP環境をセットアップ（PHP 8.3）
+3. Composer依存キャッシュを復元
+4. Composer依存をインストール
+5. テスト用 `.env` を作成（SQLite利用）
+6. マイグレーションを実行
+7. テストを実行（`php artisan test --stop-on-failure --testdox`）
+
+### 目的
+- 変更が `main` に入る前に、最低限の動作保証（マイグレーションとテスト）を自動確認する
+
+---
+
+## 2. CD（Render）
+
+Render設定は `render.yaml` と `Dockerfile` で管理されています。
+
+### デプロイ対象
+- `main` ブランチ
+
+### デプロイ方式
+- `env: docker` を利用
+- `Dockerfile` に従ってイメージをビルド
+
+### コンテナ起動フロー
+1. コンテナ起動時に `php artisan migrate --force` を実行
+2. 続けて `php artisan serve --host=0.0.0.0 --port=10000` でアプリを起動
+
+### 目的
+- `main` への反映後、自動で本番環境へデプロイし、運用をシンプルに保つ
+
+---
+
+## 3. 開発フロー（推奨）
+
+1. 機能開発用ブランチを作成
+2. 実装・ローカル確認
+3. Pull Request作成
+4. GitHub ActionsのCI成功を確認
+5. レビュー後に `main` へマージ
+6. Renderによる自動デプロイを確認
+
+---
+
+## 4. 運用時の確認ポイント
+
+- CI失敗時は、まず `composer install` / `.env` / DB設定（SQLite）を確認する
+- マイグレーション失敗時は、適用済みmigrationとの差分とDB接続情報を確認する
+- デプロイ後は主要APIの疎通確認（ヘルスチェック相当）を実施する
+

--- a/render.yaml
+++ b/render.yaml
@@ -14,8 +14,3 @@ services:
         value: base64:fx/EOA3Oli6Z3l3NwKtZc1R8VImWylMjfbELClDaUr8=
       - key: APP_URL
         value: https://score-manager-backend.onrender.com/
-
-buildCommand: |
-  composer install
-  php artisan config:clear
-  php artisan config:cache


### PR DESCRIPTION
### Motivation
- Upgrade the runtime to PHP 8.3 to align the container image with the CI environment and current PHP compatibility. 
- Ensure container startup runs migrations then launches the app as PID 1 so signals are forwarded correctly. 
- Document the repository CI/CD flow and remove redundant Render build steps to centralize build logic in the `Dockerfile`.

### Description
- Bumped the Docker base image from `php:8.2-fpm` to `php:8.3-fpm` in `Dockerfile`.
- Replaced the container `CMD` with `sh -c "php artisan migrate --force && exec php artisan serve --host=0.0.0.0 --port=10000"` so the served process replaces the shell and receives signals.
- Added `document/ci-cd-process.md` which describes the GitHub Actions CI workflow and the Render deployment flow (including that CI uses PHP 8.3 and runs migrations/tests).
- Removed the explicit `buildCommand` from `render.yaml` so image build steps are driven by the `Dockerfile`.

### Testing
- The repository CI workflow (GitHub Actions) runs `php artisan migrate` and `php artisan test --stop-on-failure --testdox`, and the workflow completed successfully. 
- The Dockerfile changes were lint-validated and a local container start was exercised to confirm the new `CMD` runs migrations and launches the server successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f57268d88330b934ee114e3f4c1f)