### PR TITLE
[codex] Add shop creation flow

### DIFF
--- a/app/Http/Controllers/AdminShopController.php
+++ b/app/Http/Controllers/AdminShopController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace App\Http\Controllers;
 
 use App\Models\Shop;
@@ -7,39 +8,68 @@ use Illuminate\Http\Request;
 class AdminShopController extends Controller
 {
     public function index(Request $request)
-{
-    $keyword = $request->string('keyword')->toString();
+    {
+        $keyword = $request->string('keyword')->toString();
 
-    // 共通クエリ（検索条件はそのまま）
-    $base = \App\Models\Shop::query()
-        ->when($keyword, function ($query) use ($keyword) {
-            $query->where(function ($q) use ($keyword) {
-                $q->where('name', 'like', "%{$keyword}%")
-                  ->orWhere('address', 'like', "%{$keyword}%");
+        // 共通クエリ（検索条件はそのまま）
+        $base = Shop::query()
+            ->when($keyword, function ($query) use ($keyword) {
+                $query->where(function ($q) use ($keyword) {
+                    $q->where('name', 'like', "%{$keyword}%")
+                        ->orWhere('address', 'like', "%{$keyword}%");
+                });
             });
-        });
 
-    // 件数（同一条件で集計）
-    $totalCount     = (clone $base)->count();                           // 全 ○ 件
-    $publishedCount = (clone $base)->where('is_deleted', false)->count(); // 公開中 ○ 件
+        // 件数（同一条件で集計）
+        $totalCount = (clone $base)->count();                           // 全 ○ 件
+        $publishedCount = (clone $base)->where('is_deleted', false)->count(); // 公開中 ○ 件
 
-    // 一覧本体（現状どおり全件取得）
-    $shops = (clone $base)
-        ->orderBy('id', 'asc')
-        ->get();
+        // 一覧本体（現状どおり全件取得）
+        $shops = (clone $base)
+            ->orderBy('id', 'asc')
+            ->get();
 
-    return view('shops.index', compact('shops', 'totalCount', 'publishedCount'));
-}
+        return view('shops.index', compact('shops', 'totalCount', 'publishedCount'));
+    }
+
+    public function create()
+    {
+        return view('shops.create');
+    }
+
+    public function store(Request $request)
+    {
+        $data = $this->validateShop($request);
+        $data['is_deleted'] = $request->has('is_deleted');
+
+        Shop::create($data);
+
+        return redirect()->route('shops.index')->with('success', 'Shop created successfully.');
+    }
 
     public function edit($id)
     {
         $shop = Shop::findOrFail($id);
+
         return view('shops.edit', compact('shop'));
     }
 
     public function update(Request $request, $id)
     {
-        $data = $request->validate([
+        $data = $this->validateShop($request);
+
+        // 論理削除の値を設定（チェックされていない場合はfalse）
+        $data['is_deleted'] = $request->has('is_deleted');
+
+        $shop = Shop::findOrFail($id);
+        $shop->update($data);
+
+        return redirect()->route('shops.index')->with('success', 'Shop updated successfully.');
+    }
+
+    private function validateShop(Request $request): array
+    {
+        return $request->validate([
             'name' => 'required|string|max:255',
             'address' => 'required|string|max:255',
             'lat' => 'required|numeric',
@@ -48,15 +78,5 @@ class AdminShopController extends Controller
             'number_of_machine' => 'nullable|integer',
             'description' => 'nullable|string|max:1000',
         ]);
-
-        // 論理削除の値を設定（チェックされていない場合はfalse）
-        $data['is_deleted'] = $request->has('is_deleted') ? true : false;
-
-        $shop = Shop::findOrFail($id);
-        $shop->update($data);
-
-        return redirect()->route('shops.index')->with('success', 'Shop updated successfully.');
     }
-
 }
-?>

--- a/database/sql/shops_insert.sql
+++ b/database/sql/shops_insert.sql
@@ -1,0 +1,25 @@
+INSERT INTO shops (
+    id,
+    name,
+    address,
+    lat,
+    lng,
+    price,
+    number_of_machine,
+    description,
+    is_deleted,
+    created_at,
+    updated_at
+) VALUES (
+    79,
+    'タイトーステーション大宮店',
+    '埼玉県さいたま市大宮区大門町1-1',
+    35.905813,
+    139.625705,
+    120,
+    1,
+    '大宮駅東口徒歩1分',
+    FALSE,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+);

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,6 +20,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/resources/views/shops/create.blade.php
+++ b/resources/views/shops/create.blade.php
@@ -1,0 +1,162 @@
+<!-- resources/views/shops/create.blade.php -->
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>設置店舗新規登録 | 管理システム</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --bg:#0b0f1a; --card:rgba(255,255,255,.06); --stroke:rgba(255,255,255,.12);
+      --text:rgba(255,255,255,.92); --muted:rgba(255,255,255,.65);
+      --accent1:#6C8CFF; --accent2:#9A6CFF; --danger:#ff6b6b; --success:#35d399;
+      --shadow:0 10px 30px rgba(0,0,0,.35); --radius:16px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0; padding:24px 16px; color:var(--text);
+      background: radial-gradient(1200px 800px at 10% -10%, #1b2140 0%, transparent 60%),
+                  radial-gradient(1200px 800px at 110% 20%, #331a4e 0%, transparent 60%),
+                  var(--bg);
+      font-family:"Inter",system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial,"Noto Sans JP",Meiryo,sans-serif;
+    }
+    .shell{max-width:900px; margin:0 auto;}
+    .header{display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:16px}
+    .crumbs{color:var(--muted); font-size:.95rem}
+    .title{font-size:1.6rem; font-weight:800; letter-spacing:.3px; margin:.25rem 0 0}
+    .card{background:var(--card); border:1px solid var(--stroke); border-radius:var(--radius); box-shadow:var(--shadow); backdrop-filter:blur(8px); padding:20px}
+    .errorbox{margin:0 0 12px; padding:10px 14px; border-radius:12px; border:1px solid color-mix(in srgb, var(--danger) 30%, transparent); background:color-mix(in srgb, var(--danger) 12%, transparent)}
+    .error{color: color-mix(in srgb, var(--danger) 92%, white 10%); font-size:.92rem; margin:.2rem 0 0}
+    .help{color:var(--muted); font-size:.9rem}
+    .form-grid{display:grid; grid-template-columns:1fr 1fr; gap:16px}
+    .form-row{display:flex; flex-direction:column; gap:6px}
+    .full{grid-column:1 / -1}
+    label{font-weight:700}
+    input[type=text],input[type=number],textarea{
+      width:100%; padding:.7rem .8rem; border-radius:12px; border:1px solid var(--stroke);
+      background:rgba(255,255,255,.04); color:var(--text); outline:none;
+    }
+    textarea{min-height:120px; resize:vertical}
+    .row{display:flex; align-items:center; gap:10px}
+    .switch{
+      --w:50px; --h:28px;
+      position:relative; width:var(--w); height:var(--h);
+      background:rgba(255,255,255,.08); border:1px solid var(--stroke); border-radius:999px; cursor:pointer;
+    }
+    .switch input{display:none}
+    .knob{
+      position:absolute; top:3px; left:3px; width:calc(var(--h) - 6px); height:calc(var(--h) - 6px);
+      background:#fff; border-radius:999px; transition:left .18s ease, background .18s ease;
+    }
+    .switch input:checked + .knob{ left:calc(var(--w) - var(--h) + 3px); background:linear-gradient(135deg, var(--accent1), var(--accent2));}
+    .btn{
+      appearance:none; border:1px solid var(--stroke); background:rgba(255,255,255,.06); color:var(--text);
+      padding:12px 16px; border-radius:12px; cursor:pointer; font-weight:700; display:inline-flex; align-items:center; gap:8px;
+      transition:transform .15s ease, background .15s ease; text-decoration:none;
+    }
+    .btn:hover{transform:translateY(-1px); background:rgba(255,255,255,.1)}
+    .primary{border-color:transparent; background:linear-gradient(135deg, var(--accent1), var(--accent2)); color:#fff; box-shadow:0 10px 24px rgba(108,140,255,.35)}
+    .muted{color:var(--muted)}
+    .actions{display:flex; flex-wrap:wrap; gap:10px; justify-content:flex-end; margin-top:18px}
+    @media(max-width:720px){ .form-grid{grid-template-columns:1fr} }
+    a.link{color:#c9d4ff; text-decoration:none; font-weight:600}
+    a.link:hover{text-decoration:underline}
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="header">
+      <div>
+        <div class="crumbs"><a class="link" href="{{ url('/') }}">Home</a> / <a class="link" href="{{ route('shops.index') }}">設置店舗一覧</a> / 新規登録</div>
+        <h1 class="title">設置店舗新規登録</h1>
+      </div>
+    </div>
+
+    @if($errors->any())
+      <div class="card errorbox">
+        @foreach($errors->all() as $error)
+          <div class="error">• {{ $error }}</div>
+        @endforeach
+      </div>
+    @endif
+
+    <form class="card" method="POST" action="{{ route('shops.store') }}">
+      @csrf
+
+      <div class="form-grid">
+        <div class="form-row full">
+          <label for="name">名前</label>
+          <input type="text" id="name" name="name" value="{{ old('name') }}" required>
+          @error('name') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row full">
+          <label for="address">住所</label>
+          <input type="text" id="address" name="address" value="{{ old('address') }}" required>
+          @error('address') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row">
+          <label for="lat">緯度 <span class="muted">(−90〜90)</span></label>
+          <input type="number" step="0.0000001" inputmode="decimal" id="lat" name="lat" value="{{ old('lat') }}" required>
+          @error('lat') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row">
+          <label for="lng">経度 <span class="muted">(−180〜180)</span></label>
+          <input type="number" step="0.0000001" inputmode="decimal" id="lng" name="lng" value="{{ old('lng') }}" required>
+          @error('lng') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row">
+          <label for="price">価格 <span class="muted">(円)</span></label>
+          <input type="number" id="price" name="price" min="0" step="1" value="{{ old('price') }}">
+          @error('price') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row">
+          <label for="number_of_machine">台数</label>
+          <input type="number" id="number_of_machine" name="number_of_machine" min="0" max="255" step="1" value="{{ old('number_of_machine') }}">
+          @error('number_of_machine') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row full">
+          <label for="description">説明</label>
+          <textarea id="description" name="description">{{ old('description') }}</textarea>
+          @error('description') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row full">
+          <label class="row" for="is_deleted">
+            <span>状態（公開/削除）</span>
+            <span class="help">チェックすると削除済みとして登録されます</span>
+          </label>
+          <div class="row">
+            <label class="switch" title="論理削除トグル">
+              <input type="checkbox" id="is_deleted" name="is_deleted" value="1" {{ old('is_deleted') ? 'checked' : '' }}>
+              <span class="knob"></span>
+            </label>
+            <span class="muted">{{ old('is_deleted') ? '削除済み' : '公開中' }}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="actions">
+        <a class="btn" href="{{ route('shops.index') }}">キャンセル</a>
+        <button class="btn primary" type="submit">登録する</button>
+      </div>
+    </form>
+
+    <div class="actions" style="justify-content:space-between; margin-top:14px">
+      <a class="link" href="{{ route('shops.index') }}">← 一覧に戻る</a>
+      <form method="POST" action="{{ route('logout') }}">
+        @csrf
+        <button class="btn" type="submit">ログアウト</button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>

--- a/resources/views/shops/index.blade.php
+++ b/resources/views/shops/index.blade.php
@@ -119,6 +119,7 @@
       </div>
 
       <div class="actions">
+        <a class="btn primary" href="{{ route('shops.create') }}">新規登録</a>
         <a class="btn" href="{{ url('/admin/shops') }}">再読み込み</a>
         <form method="POST" action="{{ route('logout') }}">
           @csrf

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,9 @@
 <?php
 
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\AdminShopController;
 use App\Http\Controllers\Auth\LoginController;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------
@@ -38,6 +37,8 @@ Route::prefix('admin')
     ->middleware(['auth', 'only10']) // auth でログイン必須 → only10 でID=10制限
     ->group(function () {
         Route::get('shops', [AdminShopController::class, 'index'])->name('shops.index');
+        Route::get('shops/create', [AdminShopController::class, 'create'])->name('shops.create');
+        Route::post('shops', [AdminShopController::class, 'store'])->name('shops.store');
         Route::get('shops/{shop}/edit', [AdminShopController::class, 'edit'])->name('shops.edit');
         Route::put('shops/{shop}', [AdminShopController::class, 'update'])->name('shops.update');
         // 他の管理画面ルートもここにまとめて追加

--- a/tests/Feature/AdminShopTest.php
+++ b/tests/Feature/AdminShopTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminShopTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function create_page_is_visible_to_allowed_admin(): void
+    {
+        $admin = User::factory()->create(['id' => 10]);
+
+        $this->actingAs($admin)
+            ->get('/admin/shops/create')
+            ->assertOk()
+            ->assertSee('設置店舗新規登録');
+    }
+
+    #[Test]
+    public function admin_can_store_new_shop(): void
+    {
+        $admin = User::factory()->create(['id' => 10]);
+
+        $this->actingAs($admin)
+            ->post('/admin/shops', [
+                'name' => 'タイトーステーション大宮店',
+                'address' => '埼玉県さいたま市大宮区大門町1-1',
+                'lat' => '35.905813',
+                'lng' => '139.625705',
+                'price' => '120',
+                'number_of_machine' => '1',
+                'description' => '大宮駅東口徒歩1分',
+            ])
+            ->assertRedirect(route('shops.index'));
+
+        $this->assertDatabaseHas('shops', [
+            'name' => 'タイトーステーション大宮店',
+            'address' => '埼玉県さいたま市大宮区大門町1-1',
+            'price' => 120,
+            'number_of_machine' => 1,
+            'description' => '大宮駅東口徒歩1分',
+            'is_deleted' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add create/store handling for admin shop registration
- Add a new shop creation page and list-page entry point
- Add SQL for the requested Taito Station Omiya shop data
- Add feature coverage for the admin shop creation flow

## Validation
- `php artisan test tests/Feature/AdminShopTest.php`
- `./vendor/bin/phpunit --display-warnings`

Note: PHPUnit reports 3 existing deprecations for doc-comment metadata in other tests.