### PR TITLE
[codex] Return user name for visited shops

### DIFF
--- a/app/Http/Controllers/VisitController.php
+++ b/app/Http/Controllers/VisitController.php
@@ -2,10 +2,9 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
-use Illuminate\Http\Request;
+use App\Models\User;
 use App\Models\UserVisit;
-use App\Models\Shop;
+use Illuminate\Http\Request;
 
 class VisitController extends Controller
 {
@@ -14,67 +13,73 @@ class VisitController extends Controller
         $request->validate([
             'shop_id' => 'required|exists:shops,id',
         ]);
-    
+
         $userId = $request->user()->id;
         $shopId = $request->input('shop_id');
-    
+
         // すでにチェックイン済みか？
         $alreadyVisited = UserVisit::where('user_id', $userId)
             ->where('shop_id', $shopId)
             ->exists();
-    
+
         if ($alreadyVisited) {
             return response()->json(['message' => 'すでにチェックイン済みです'], 409);
         }
-    
+
         // チェックイン登録（created_at に訪問時刻が自動で入る）
         UserVisit::create([
             'user_id' => $userId,
             'shop_id' => $shopId,
         ]);
-    
+
         return response()->json(['message' => 'チェックインが完了しました'], 201);
     }
-    
-    // 行脚済み店舗一覧取得    
+
+    // 行脚済み店舗一覧取得
     public function index(Request $request)
-{
-    $userId = $request->user()->id;
+    {
+        $userId = $request->user()->id;
 
-    $visited = UserVisit::with('shop')
-        ->where('user_id', $userId)
-        ->orderBy('created_at', 'desc')
+        $visited = UserVisit::with('shop')
+            ->where('user_id', $userId)
+            ->orderBy('created_at', 'desc')
 
-        ->get();
+            ->get();
 
-    return response()->json($visited);
-}
-
-
-// 任意ユーザーの行脚店舗一覧（非ログインでも取得可能）
-public function publicIndex(Request $request)
-{
-    $userId = $request->query('user');
-
-    if (!$userId || !is_numeric($userId)) {
-        return response()->json(['message' => 'userパラメータが必要です'], 400);
+        return response()->json($visited);
     }
 
-    $visited = UserVisit::with('shop')
-    ->where('user_id', $userId)
-    ->orderBy('created_at', 'desc')
-    ->get()
-    ->map(function ($visit) {
-        return [
-            'id' => $visit->shop->id,
-            'name' => $visit->shop->name,
-            'address' => $visit->shop->address,
-            'created_at' => $visit->created_at, // ← これを追加！
-        ];
-    });
+    // 任意ユーザーの行脚店舗一覧（非ログインでも取得可能）
+    public function publicIndex(Request $request)
+    {
+        $userId = $request->query('user');
 
-    return response()->json($visited);
-}
+        if (! $userId || ! is_numeric($userId)) {
+            return response()->json(['message' => 'userパラメータが必要です'], 400);
+        }
 
+        $user = User::find($userId);
 
+        if (! $user) {
+            return response()->json(['message' => 'ユーザーが見つかりません'], 404);
+        }
+
+        $visited = UserVisit::with('shop')
+            ->where('user_id', $userId)
+            ->orderBy('created_at', 'desc')
+            ->get()
+            ->map(function ($visit) {
+                return [
+                    'id' => $visit->shop->id,
+                    'name' => $visit->shop->name,
+                    'address' => $visit->shop->address,
+                    'created_at' => $visit->created_at, // ← これを追加！
+                ];
+            });
+
+        return response()->json([
+            'user_name' => $user->name,
+            'visited_shops' => $visited,
+        ]);
+    }
 }

--- a/tests/Feature/VisitApiTest.php
+++ b/tests/Feature/VisitApiTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Feature;
 
-use App\Models\User;
 use App\Models\Shop;
+use App\Models\User;
 use App\Models\UserVisit;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
@@ -20,7 +20,7 @@ class VisitApiTest extends TestCase
         $shop = Shop::factory()->create();
 
         $this->postJson('/api/visit', ['shop_id' => $shop->id])
-             ->assertStatus(401);
+            ->assertStatus(401);
     }
 
     #[Test]
@@ -31,8 +31,8 @@ class VisitApiTest extends TestCase
         Sanctum::actingAs($user);
 
         $this->postJson('/api/visit', ['shop_id' => $shop->id])
-             ->assertCreated()
-             ->assertJson(['message' => 'チェックインが完了しました']);
+            ->assertCreated()
+            ->assertJson(['message' => 'チェックインが完了しました']);
 
         $this->assertDatabaseHas('user_visits', [
             'user_id' => $user->id,
@@ -50,8 +50,8 @@ class VisitApiTest extends TestCase
         Sanctum::actingAs($user);
 
         $this->postJson('/api/visit', ['shop_id' => $shop->id])
-             ->assertStatus(409)
-             ->assertJson(['message' => 'すでにチェックイン済みです']);
+            ->assertStatus(409)
+            ->assertJson(['message' => 'すでにチェックイン済みです']);
     }
 
     #[Test]
@@ -64,17 +64,17 @@ class VisitApiTest extends TestCase
         Sanctum::actingAs($user);
 
         $this->getJson('/api/visited')
-             ->assertOk()
-             ->assertJsonIsArray()
-             ->assertJsonFragment(['name' => $shop->name]);
+            ->assertOk()
+            ->assertJsonIsArray()
+            ->assertJsonFragment(['name' => $shop->name]);
     }
 
     #[Test]
     public function public_index_requires_user_query(): void
     {
         $this->getJson('/api/visited-shops')
-             ->assertStatus(400)
-             ->assertJson(['message' => 'userパラメータが必要です']);
+            ->assertStatus(400)
+            ->assertJson(['message' => 'userパラメータが必要です']);
     }
 
     #[Test]
@@ -85,13 +85,24 @@ class VisitApiTest extends TestCase
         UserVisit::factory()->create(['user_id' => $user->id, 'shop_id' => $shop->id]);
 
         $this->getJson("/api/visited-shops?user={$user->id}")
-             ->assertOk()
-             ->assertJsonIsArray()
-             ->assertJsonFragment([
-                 'id'   => $shop->id,
-                 'name' => $shop->name,
-                 'address' => $shop->address,
-             ]);
+            ->assertOk()
+            ->assertJsonPath('user_name', $user->name)
+            ->assertJsonFragment([
+                'id' => $shop->id,
+                'name' => $shop->name,
+                'address' => $shop->address,
+            ]);
+    }
+
+    #[Test]
+    public function public_index_returns_user_name_when_user_has_no_visits(): void
+    {
+        $user = User::factory()->create();
+
+        $this->getJson("/api/visited-shops?user={$user->id}")
+            ->assertOk()
+            ->assertJsonPath('user_name', $user->name)
+            ->assertJsonPath('visited_shops', []);
     }
 
     // 任意：バリデーション422を抑えておくとより実務的
@@ -102,6 +113,6 @@ class VisitApiTest extends TestCase
         Sanctum::actingAs($user);
 
         $this->postJson('/api/visit', ['shop_id' => 999999])
-             ->assertStatus(422); // exists:shops,id によるバリデーション
+            ->assertStatus(422); // exists:shops,id によるバリデーション
     }
 }


### PR DESCRIPTION
## Summary
- Update `/api/visited-shops` to return the target user's `name` as `user_name`.
- Return visits under `visited_shops` so the frontend can show the user's title even when there are no visit records.
- Add feature coverage for user-name responses, including users with no visits.

## Related Issue
- https://github.com/misato729/score-manager-frontend/issues/29

## Validation
- `vendor/bin/pint app/Http/Controllers/VisitController.php tests/Feature/VisitApiTest.php`
- `php artisan test --filter=VisitApiTest`