### PR TITLE
[codex] テスト太郎のアカウント削除を禁止

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -2,14 +2,16 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
-use App\Models\User;
-use App\Models\Song;
 use App\Models\Score;
+use App\Models\Song;
+use App\Models\User;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 
 class UserController extends Controller
 {
+    private const PROTECTED_USER_ID = 8;
+
     public function store(Request $request)
     {
         // ✅ バリデーション（必要に応じて調整）
@@ -44,14 +46,18 @@ class UserController extends Controller
     public function destroy($id, Request $request)
     {
         $user = User::findOrFail($id);
-    
+
         // ✅ 修正：auth() ではなく request->user()
-        if ($request->user()->id !== (int)$id) {
+        if ($request->user()->id !== (int) $id) {
             return response()->json(['message' => 'Unauthorized'], 403);
         }
-    
+
+        if ($user->id === self::PROTECTED_USER_ID) {
+            return response()->json(['message' => 'This account cannot be deleted'], 403);
+        }
+
         $user->delete();
-    
+
         return response()->json(['message' => 'Account deleted']);
     }
 
@@ -63,9 +69,7 @@ class UserController extends Controller
         ]);
         $user->target = $validated['target'];
         $user->save();
-    
+
         return response()->json(['message' => 'Target updated successfully']);
     }
-
-
 }

--- a/tests/Feature/UserApiTest.php
+++ b/tests/Feature/UserApiTest.php
@@ -25,8 +25,8 @@ class UserApiTest extends TestCase
         Sanctum::actingAs($user);
 
         $this->getJson('/api/user')
-             ->assertOk()
-             ->assertJsonPath('id', $user->id);
+            ->assertOk()
+            ->assertJsonPath('id', $user->id);
     }
 
     #[Test]
@@ -38,11 +38,41 @@ class UserApiTest extends TestCase
         $payload = ['target' => 'AAA']; // 仕様に合わせて変更
 
         $this->putJson('/api/users/target', $payload)
-             ->assertOk();
+            ->assertOk();
 
         $this->assertDatabaseHas('users', [
-            'id'     => $user->id,
+            'id' => $user->id,
             'target' => 'AAA',
         ]);
+    }
+
+    #[Test]
+    public function protected_test_user_cannot_delete_their_account(): void
+    {
+        $user = User::factory()->create(['id' => 8]);
+        Sanctum::actingAs($user);
+
+        $this->deleteJson('/api/users/8')
+            ->assertForbidden()
+            ->assertJson([
+                'message' => 'This account cannot be deleted',
+            ]);
+
+        $this->assertDatabaseHas('users', ['id' => 8]);
+    }
+
+    #[Test]
+    public function regular_user_can_delete_their_account(): void
+    {
+        $user = User::factory()->create(['id' => 9]);
+        Sanctum::actingAs($user);
+
+        $this->deleteJson('/api/users/9')
+            ->assertOk()
+            ->assertJson([
+                'message' => 'Account deleted',
+            ]);
+
+        $this->assertDatabaseMissing('users', ['id' => 9]);
     }
 }


### PR DESCRIPTION
## 概要

仕様体験用アカウント「テスト太郎（ユーザー ID 8）」を、API を直接呼び出した場合でも削除できないようにしました。

Closes #36

## 変更内容

- `UserController::destroy` に保護対象ユーザー ID を定義
- 本人による削除リクエストでも、ユーザー ID 8 の場合は HTTP 403 を返却
- ID 8 のアカウントが削除されず残る Feature テストを追加
- 通常ユーザーの削除が従来どおり成功する回帰テストを追加

## 影響

ユーザー ID 8 の削除 API は `This account cannot be deleted` を返し、アカウントを保持します。その他のユーザーの削除挙動は変わりません。

## 検証

- `ALLOWED_USER_ID=10 php artisan test`（28 tests / 67 assertions passed）
- `./vendor/bin/pint --test app/Http/Controllers/UserController.php tests/Feature/UserApiTest.php`

ローカル `.env` は `ALLOWED_USER_ID=1` のため、環境変数を指定しない全体テストでは既存の `AdminShopTest` 2件が 403 になります。テスト想定値の ID 10 を明示すると全件通過します。