### PR TITLE
Add admin song management

### DIFF
--- a/app/Http/Controllers/AdminSongController.php
+++ b/app/Http/Controllers/AdminSongController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Song;
+use Illuminate\Http\Request;
+
+class AdminSongController extends Controller
+{
+    public function index(Request $request)
+    {
+        $keyword = $request->string('keyword')->toString();
+
+        $songs = Song::query()
+            ->when($keyword, function ($query) use ($keyword) {
+                $query->where(function ($q) use ($keyword) {
+                    $q->where('title', 'like', "%{$keyword}%")
+                        ->orWhere('jiriki_rank', 'like', "%{$keyword}%");
+                });
+            })
+            ->orderBy('id')
+            ->get();
+
+        return view('songs.index', [
+            'songs' => $songs,
+            'totalCount' => $songs->count(),
+        ]);
+    }
+
+    public function edit(Song $song)
+    {
+        return view('songs.edit', compact('song'));
+    }
+
+    public function update(Request $request, Song $song)
+    {
+        $data = $request->validate([
+            'title' => 'required|string|max:255',
+            'jiriki_rank' => 'required|string|max:20',
+        ]);
+
+        $song->update($data);
+
+        return redirect()->route('songs.index')->with('success', 'Song updated successfully.');
+    }
+}

--- a/app/Http/Controllers/SongController.php
+++ b/app/Http/Controllers/SongController.php
@@ -2,23 +2,12 @@
 
 namespace App\Http\Controllers;
 
-use Illuminate\Http\Request;
+use App\Models\Song;
 
 class SongController extends Controller
 {
-    public funtion index()
+    public function index()
     {
-        // ここでは、全ての楽曲情報を取得して返す処理を実装します。
-        // 例えば、Songモデルを使用してデータベースから楽曲情報を取得することができます。
-
-        // 例:
-        // $songs = Song::all();
-        // return response()->json($songs);
-
-        return response()->json([
-            'message' => 'This is a placeholder for the song list API.',
-            'songs' => [] // 実際のデータはここに入ります
-        ]);
+        return response()->json(Song::orderBy('id')->get());
     }
-    ]
 }

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -2,11 +2,15 @@
 
 namespace App\Models;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
 
 class Song extends Model
 {
     use HasFactory;
-    //
+
+    protected $fillable = [
+        'title',
+        'jiriki_rank',
+    ];
 }

--- a/resources/views/songs/edit.blade.php
+++ b/resources/views/songs/edit.blade.php
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>楽曲編集 | 管理システム</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --bg:#0b0f1a; --card:rgba(255,255,255,.06); --stroke:rgba(255,255,255,.12);
+      --text:rgba(255,255,255,.92); --muted:rgba(255,255,255,.65);
+      --accent1:#6C8CFF; --accent2:#9A6CFF; --danger:#ff6b6b;
+      --shadow:0 10px 30px rgba(0,0,0,.35); --radius:16px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0; padding:24px 16px; color:var(--text);
+      background:radial-gradient(1200px 800px at 10% -10%, #1b2140 0%, transparent 60%),
+                 radial-gradient(1200px 800px at 110% 20%, #331a4e 0%, transparent 60%),
+                 var(--bg);
+      font-family:"Inter",system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial,"Noto Sans JP",Meiryo,sans-serif;
+    }
+    .shell{max-width:760px; margin:0 auto}
+    .header{display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:16px}
+    .crumbs{color:var(--muted); font-size:.95rem}
+    .title{font-size:1.6rem; font-weight:800; letter-spacing:.3px; margin:.25rem 0 0}
+    .card{background:var(--card); border:1px solid var(--stroke); border-radius:var(--radius); box-shadow:var(--shadow); backdrop-filter:blur(8px); padding:20px}
+    .errorbox{margin:0 0 12px; padding:10px 14px; border-radius:12px; border:1px solid color-mix(in srgb,var(--danger) 30%,transparent); background:color-mix(in srgb,var(--danger) 12%,transparent)}
+    .error{color:color-mix(in srgb,var(--danger) 92%,white 10%); font-size:.92rem; margin:.2rem 0 0}
+    .form-grid{display:grid; grid-template-columns:1fr; gap:16px}
+    .form-row{display:flex; flex-direction:column; gap:6px}
+    label{font-weight:700}
+    input[type=text]{width:100%; padding:.7rem .8rem; border-radius:12px; border:1px solid var(--stroke); background:rgba(255,255,255,.04); color:var(--text); outline:none}
+    .btn{appearance:none; border:1px solid var(--stroke); background:rgba(255,255,255,.06); color:var(--text); padding:12px 16px; border-radius:12px; cursor:pointer; font-weight:700; display:inline-flex; align-items:center; gap:8px; text-decoration:none}
+    .btn:hover{background:rgba(255,255,255,.1)}
+    .primary{border-color:transparent; background:linear-gradient(135deg,var(--accent1),var(--accent2)); color:#fff; box-shadow:0 10px 24px rgba(108,140,255,.35)}
+    .muted{color:var(--muted)}
+    .actions{display:flex; flex-wrap:wrap; gap:10px; justify-content:flex-end; margin-top:18px}
+    .link{color:#c9d4ff; text-decoration:none; font-weight:600}
+    .link:hover{text-decoration:underline}
+    @media(max-width:720px){.header{align-items:flex-start; flex-direction:column}.title{font-size:1.4rem}}
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="header">
+      <div>
+        <div class="crumbs"><a class="link" href="{{ url('/') }}">Home</a> / <a class="link" href="{{ route('songs.index') }}">楽曲一覧</a> / 編集</div>
+        <h1 class="title">楽曲編集 <span class="muted">#{{ $song->id }}</span></h1>
+      </div>
+    </div>
+
+    @if($errors->any())
+      <div class="card errorbox">
+        @foreach($errors->all() as $error)
+          <div class="error">• {{ $error }}</div>
+        @endforeach
+      </div>
+    @endif
+
+    <form class="card" method="POST" action="{{ route('songs.update', $song->id) }}">
+      @csrf
+      @method('PUT')
+
+      <div class="form-grid">
+        <div class="form-row">
+          <label for="title">曲名</label>
+          <input type="text" id="title" name="title" value="{{ old('title', $song->title) }}" required>
+          @error('title') <div class="error">{{ $message }}</div> @enderror
+        </div>
+
+        <div class="form-row">
+          <label for="jiriki_rank">地力ランク</label>
+          <input type="text" id="jiriki_rank" name="jiriki_rank" value="{{ old('jiriki_rank', $song->jiriki_rank) }}" required>
+          @error('jiriki_rank') <div class="error">{{ $message }}</div> @enderror
+        </div>
+      </div>
+
+      <div class="actions">
+        <a class="btn" href="{{ route('songs.index') }}">キャンセル</a>
+        <button class="btn primary" type="submit">更新する</button>
+      </div>
+    </form>
+
+    <div class="actions" style="justify-content:space-between; margin-top:14px">
+      <a class="link" href="{{ route('songs.index') }}">← 一覧に戻る</a>
+      <form method="POST" action="{{ route('logout') }}">
+        @csrf
+        <button class="btn" type="submit">ログアウト</button>
+      </form>
+    </div>
+  </div>
+</body>
+</html>

--- a/resources/views/songs/index.blade.php
+++ b/resources/views/songs/index.blade.php
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>楽曲一覧 | 管理システム</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;800&display=swap" rel="stylesheet">
+  <style>
+    :root{
+      --bg:#0b0f1a; --card:rgba(255,255,255,.06); --stroke:rgba(255,255,255,.12);
+      --text:rgba(255,255,255,.92); --muted:rgba(255,255,255,.65);
+      --accent1:#6C8CFF; --accent2:#9A6CFF; --success:#35d399;
+      --shadow:0 10px 30px rgba(0,0,0,.35); --radius:16px;
+    }
+    *{box-sizing:border-box}
+    html,body{height:100%}
+    body{
+      margin:0; padding:24px 16px; color:var(--text);
+      background:radial-gradient(1200px 800px at 10% -10%, #1b2140 0%, transparent 60%),
+                 radial-gradient(1200px 800px at 110% 20%, #331a4e 0%, transparent 60%),
+                 var(--bg);
+      font-family:"Inter",system-ui,-apple-system,Segoe UI,Roboto,"Helvetica Neue",Arial,"Noto Sans JP",Meiryo,sans-serif;
+    }
+    .shell{max-width:1000px; margin:0 auto}
+    .header{display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:16px}
+    .title{font-size:1.6rem; font-weight:800; letter-spacing:.3px}
+    .crumbs{color:var(--muted); font-size:.95rem}
+    .card{background:var(--card); border:1px solid var(--stroke); border-radius:var(--radius); box-shadow:var(--shadow); backdrop-filter:blur(8px)}
+    .toolbar{display:flex; flex-wrap:wrap; gap:10px; align-items:center; padding:16px}
+    .search{flex:1 1 320px; display:flex; align-items:center; gap:8px; padding:10px 12px; border-radius:12px; border:1px solid var(--stroke); background:rgba(255,255,255,.04)}
+    .search input{width:100%; padding:6px 4px; background:transparent; border:0; outline:none; color:var(--text); font-size:1rem}
+    .btn{appearance:none; border:1px solid var(--stroke); background:rgba(255,255,255,.06); color:var(--text); padding:10px 14px; border-radius:12px; cursor:pointer; font-weight:600; display:inline-flex; align-items:center; gap:8px; text-decoration:none}
+    .btn:hover{background:rgba(255,255,255,.1)}
+    .primary{border-color:transparent; background:linear-gradient(135deg,var(--accent1),var(--accent2)); color:#fff; box-shadow:0 10px 24px rgba(108,140,255,.35)}
+    .meta{padding:0 16px 12px; color:var(--muted); font-size:.95rem}
+    .table-wrap{overflow:auto; border-top:1px solid var(--stroke)}
+    table{width:100%; border-collapse:separate; border-spacing:0}
+    thead th{position:sticky; top:0; z-index:2; background:rgba(15,20,35,.9); text-align:left; font-weight:700; color:var(--muted); font-size:.9rem; padding:12px 14px; border-bottom:1px solid var(--stroke)}
+    tbody td{padding:12px 14px; border-bottom:1px solid var(--stroke); vertical-align:top}
+    tbody tr:hover{background:rgba(255,255,255,.03)}
+    .mono{font-variant-numeric:tabular-nums}
+    .actions{display:flex; gap:8px; align-items:center}
+    .link{color:#c9d4ff; text-decoration:none; font-weight:600}
+    .link:hover{text-decoration:underline}
+    .toast{margin:10px 0 16px; padding:10px 14px; border-radius:12px; border:1px solid color-mix(in srgb,var(--success) 30%,transparent); background:color-mix(in srgb,var(--success) 10%,transparent); color:color-mix(in srgb,var(--success) 92%,white 10%)}
+    @media(max-width:720px){.header{align-items:flex-start; flex-direction:column}.title{font-size:1.4rem}thead th,tbody td{padding:10px 12px}}
+  </style>
+</head>
+<body>
+  <div class="shell">
+    <div class="header">
+      <div>
+        <div class="crumbs"><a class="link" href="{{ url('/') }}">Home</a> / 楽曲一覧</div>
+        <h1 class="title" style="margin:.25rem 0 0">楽曲一覧</h1>
+      </div>
+      <div class="actions">
+        <a class="btn" href="{{ route('shops.index') }}">設置店舗一覧</a>
+        <a class="btn" href="{{ route('songs.index') }}">再読み込み</a>
+        <form method="POST" action="{{ route('logout') }}">
+          @csrf
+          <button class="btn" type="submit">ログアウト</button>
+        </form>
+      </div>
+    </div>
+
+    @if(session('success'))
+      <div class="toast">{{ session('success') }}</div>
+    @endif
+
+    <section class="card">
+      <div class="toolbar">
+        <form method="GET" action="{{ route('songs.index') }}" class="search" role="search">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="m21 21-4.3-4.3M10.8 18.5a7.7 7.7 0 1 1 0-15.4 7.7 7.7 0 0 1 0 15.4Z" stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/></svg>
+          <input type="search" name="keyword" value="{{ request('keyword') }}" placeholder="曲名・地力ランクで検索…" />
+          <button class="btn" type="submit">検索</button>
+        </form>
+      </div>
+
+      <div class="meta">全 <strong>{{ number_format($totalCount) }}</strong> 件を表示</div>
+
+      <div class="table-wrap">
+        <table aria-label="楽曲一覧">
+          <thead>
+            <tr>
+              <th style="width:80px">ID</th>
+              <th>曲名</th>
+              <th style="width:180px">地力ランク</th>
+              <th style="width:180px">更新日時</th>
+              <th style="width:120px">操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            @forelse($songs as $song)
+              <tr>
+                <td class="mono">{{ $song->id }}</td>
+                <td><a class="link" href="{{ route('songs.edit', $song->id) }}">{{ $song->title }}</a></td>
+                <td>{{ $song->jiriki_rank }}</td>
+                <td class="mono">{{ optional($song->updated_at)->format('Y-m-d H:i') }}</td>
+                <td><a class="btn" href="{{ route('songs.edit', $song->id) }}">編集</a></td>
+              </tr>
+            @empty
+              <tr>
+                <td colspan="5" style="text-align:center; color:var(--muted); padding:24px;">データがありません</td>
+              </tr>
+            @endforelse
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\AdminShopController;
+use App\Http\Controllers\AdminSongController;
 use App\Http\Controllers\Auth\LoginController;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
@@ -41,5 +42,8 @@ Route::prefix('admin')
         Route::post('shops', [AdminShopController::class, 'store'])->name('shops.store');
         Route::get('shops/{shop}/edit', [AdminShopController::class, 'edit'])->name('shops.edit');
         Route::put('shops/{shop}', [AdminShopController::class, 'update'])->name('shops.update');
+        Route::get('songs', [AdminSongController::class, 'index'])->name('songs.index');
+        Route::get('songs/{song}/edit', [AdminSongController::class, 'edit'])->name('songs.edit');
+        Route::put('songs/{song}', [AdminSongController::class, 'update'])->name('songs.update');
         // 他の管理画面ルートもここにまとめて追加
     });

--- a/tests/Feature/AdminSongTest.php
+++ b/tests/Feature/AdminSongTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Song;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminSongTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function index_page_is_visible_to_allowed_admin(): void
+    {
+        $admin = $this->allowedAdmin();
+        Song::factory()->create([
+            'title' => 'FLOWER',
+            'jiriki_rank' => 'S+',
+        ]);
+
+        $this->actingAs($admin)
+            ->get('/admin/songs')
+            ->assertOk()
+            ->assertSee('楽曲一覧')
+            ->assertSee('FLOWER')
+            ->assertSee('S+');
+    }
+
+    #[Test]
+    public function edit_page_is_visible_to_allowed_admin(): void
+    {
+        $admin = $this->allowedAdmin();
+        $song = Song::factory()->create([
+            'title' => '灼熱Beach Side Bunny',
+            'jiriki_rank' => 'A',
+        ]);
+
+        $this->actingAs($admin)
+            ->get("/admin/songs/{$song->id}/edit")
+            ->assertOk()
+            ->assertSee('楽曲編集')
+            ->assertSee('灼熱Beach Side Bunny');
+    }
+
+    #[Test]
+    public function admin_can_update_song(): void
+    {
+        $admin = $this->allowedAdmin();
+        $song = Song::factory()->create([
+            'title' => '旧曲名',
+            'jiriki_rank' => 'B',
+        ]);
+
+        $this->actingAs($admin)
+            ->put("/admin/songs/{$song->id}", [
+                'title' => '新曲名',
+                'jiriki_rank' => 'AA',
+            ])
+            ->assertRedirect(route('songs.index'));
+
+        $this->assertDatabaseHas('songs', [
+            'id' => $song->id,
+            'title' => '新曲名',
+            'jiriki_rank' => 'AA',
+        ]);
+    }
+
+    #[Test]
+    public function non_allowed_user_cannot_access_song_admin(): void
+    {
+        $user = User::factory()->create(['id' => (int) env('ALLOWED_USER_ID', 10) + 1]);
+
+        $this->actingAs($user)
+            ->get('/admin/songs')
+            ->assertForbidden();
+    }
+
+    private function allowedAdmin(): User
+    {
+        return User::factory()->create(['id' => (int) env('ALLOWED_USER_ID', 10)]);
+    }
+}


### PR DESCRIPTION
## Summary
- Add an admin song list and edit screen under `/admin/songs`
- Add song update handling with validation and mass assignment support
- Add feature tests for allowed admin access, editing, updates, and forbidden access
- Fix the existing `SongController` syntax issue and return the song list JSON

## Validation
- `./vendor/bin/pint app/Http/Controllers/AdminSongController.php app/Http/Controllers/SongController.php app/Models/Song.php routes/web.php tests/Feature/AdminSongTest.php`
- `php artisan test`

Closes #4