### PR TITLE
楽曲管理画面の地力ランクをプルダウン化

### DIFF
--- a/app/Http/Controllers/AdminSongController.php
+++ b/app/Http/Controllers/AdminSongController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Song;
 use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
 
 class AdminSongController extends Controller
 {
@@ -29,14 +30,17 @@ class AdminSongController extends Controller
 
     public function edit(Song $song)
     {
-        return view('songs.edit', compact('song'));
+        return view('songs.edit', [
+            'song' => $song,
+            'jirikiRanks' => Song::JIRIKI_RANKS,
+        ]);
     }
 
     public function update(Request $request, Song $song)
     {
         $data = $request->validate([
             'title' => 'required|string|max:255',
-            'jiriki_rank' => 'required|string|max:20',
+            'jiriki_rank' => ['required', 'string', Rule::in(Song::JIRIKI_RANKS)],
         ]);
 
         $song->update($data);

--- a/app/Models/Song.php
+++ b/app/Models/Song.php
@@ -9,6 +9,19 @@ class Song extends Model
 {
     use HasFactory;
 
+    public const JIRIKI_RANKS = [
+        'S+',
+        'S',
+        'A+',
+        'A',
+        'B+',
+        'B',
+        'C',
+        'D',
+        'E',
+        'F',
+    ];
+
     protected $fillable = [
         'title',
         'jiriki_rank',

--- a/database/factories/SongFactory.php
+++ b/database/factories/SongFactory.php
@@ -13,7 +13,7 @@ class SongFactory extends Factory
     {
         return [
             'title'       => $this->faker->unique()->sentence(3),
-            'jiriki_rank' => $this->faker->randomElement(['S', 'AAA', 'AA', 'A', 'B']),
+            'jiriki_rank' => $this->faker->randomElement(Song::JIRIKI_RANKS),
         ];
     }
 }

--- a/resources/views/songs/edit.blade.php
+++ b/resources/views/songs/edit.blade.php
@@ -32,7 +32,9 @@
     .form-grid{display:grid; grid-template-columns:1fr; gap:16px}
     .form-row{display:flex; flex-direction:column; gap:6px}
     label{font-weight:700}
-    input[type=text]{width:100%; padding:.7rem .8rem; border-radius:12px; border:1px solid var(--stroke); background:rgba(255,255,255,.04); color:var(--text); outline:none}
+    input[type=text],select{width:100%; padding:.7rem .8rem; border-radius:12px; border:1px solid var(--stroke); background:rgba(255,255,255,.04); color:var(--text); outline:none}
+    select{appearance:auto}
+    select option{background:#0b0f1a; color:var(--text)}
     .btn{appearance:none; border:1px solid var(--stroke); background:rgba(255,255,255,.06); color:var(--text); padding:12px 16px; border-radius:12px; cursor:pointer; font-weight:700; display:inline-flex; align-items:center; gap:8px; text-decoration:none}
     .btn:hover{background:rgba(255,255,255,.1)}
     .primary{border-color:transparent; background:linear-gradient(135deg,var(--accent1),var(--accent2)); color:#fff; box-shadow:0 10px 24px rgba(108,140,255,.35)}
@@ -73,7 +75,11 @@
 
         <div class="form-row">
           <label for="jiriki_rank">地力ランク</label>
-          <input type="text" id="jiriki_rank" name="jiriki_rank" value="{{ old('jiriki_rank', $song->jiriki_rank) }}" required>
+          <select id="jiriki_rank" name="jiriki_rank" required>
+            @foreach($jirikiRanks as $rank)
+              <option value="{{ $rank }}" @selected(old('jiriki_rank', $song->jiriki_rank) === $rank)>{{ $rank }}</option>
+            @endforeach
+          </select>
           @error('jiriki_rank') <div class="error">{{ $message }}</div> @enderror
         </div>
       </div>

--- a/tests/Feature/AdminSongTest.php
+++ b/tests/Feature/AdminSongTest.php
@@ -42,7 +42,11 @@ class AdminSongTest extends TestCase
             ->get("/admin/songs/{$song->id}/edit")
             ->assertOk()
             ->assertSee('楽曲編集')
-            ->assertSee('灼熱Beach Side Bunny');
+            ->assertSee('灼熱Beach Side Bunny')
+            ->assertSee('<select id="jiriki_rank" name="jiriki_rank" required>', false)
+            ->assertSee('value="S+"', false)
+            ->assertSee('value="A" selected', false)
+            ->assertSee('value="F"', false);
     }
 
     #[Test]
@@ -57,14 +61,39 @@ class AdminSongTest extends TestCase
         $this->actingAs($admin)
             ->put("/admin/songs/{$song->id}", [
                 'title' => '新曲名',
-                'jiriki_rank' => 'AA',
+                'jiriki_rank' => 'A+',
             ])
             ->assertRedirect(route('songs.index'));
 
         $this->assertDatabaseHas('songs', [
             'id' => $song->id,
             'title' => '新曲名',
-            'jiriki_rank' => 'AA',
+            'jiriki_rank' => 'A+',
+        ]);
+    }
+
+    #[Test]
+    public function admin_cannot_update_song_with_invalid_jiriki_rank(): void
+    {
+        $admin = $this->allowedAdmin();
+        $song = Song::factory()->create([
+            'title' => '旧曲名',
+            'jiriki_rank' => 'B',
+        ]);
+
+        $this->actingAs($admin)
+            ->from("/admin/songs/{$song->id}/edit")
+            ->put("/admin/songs/{$song->id}", [
+                'title' => '新曲名',
+                'jiriki_rank' => 'AA',
+            ])
+            ->assertRedirect("/admin/songs/{$song->id}/edit")
+            ->assertSessionHasErrors('jiriki_rank');
+
+        $this->assertDatabaseHas('songs', [
+            'id' => $song->id,
+            'title' => '旧曲名',
+            'jiriki_rank' => 'B',
         ]);
     }
 


### PR DESCRIPTION
## Summary
- 楽曲編集画面の地力ランク欄を自由入力から選択式に変更
- 選択肢を `Song::JIRIKI_RANKS` に集約し、更新時のバリデーションにも適用
- 管理画面の表示と不正な地力ランク拒否の Feature test を追加

## Validation
- `php artisan test tests/Feature/AdminSongTest.php`
- `php artisan test`

Closes #41