### PR TITLE
一覧テーブルの表示崩れ修正

### DIFF
--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -64,7 +64,7 @@
     .meta{padding:0 16px 12px; color:var(--muted); font-size:.95rem}
     .table-wrap{overflow:auto; border-top:1px solid var(--stroke)}
     table{width:100%; border-collapse:separate; border-spacing:0}
-    thead th{position:sticky; top:var(--header-height); z-index:2; background:#202633; text-align:left; font-weight:700; color:var(--muted); font-size:.9rem; padding:12px 14px; border-bottom:1px solid var(--stroke)}
+    thead th{background:#202633; text-align:left; font-weight:700; color:var(--muted); font-size:.9rem; padding:12px 14px; border-bottom:1px solid var(--stroke)}
     tbody td{padding:12px 14px; border-bottom:1px solid var(--stroke); vertical-align:top}
     tbody tr:hover{background:#1d2330}
     .mono{font-variant-numeric:tabular-nums}

--- a/resources/views/shops/index.blade.php
+++ b/resources/views/shops/index.blade.php
@@ -39,7 +39,6 @@
             <th style="width:80px">ID</th>
             <th>店舗名</th>
             <th>住所</th>
-            <th class="mono">都道府県</th>
             <th class="mono">緯度</th>
             <th class="mono">経度</th>
             <th class="mono">価格</th>
@@ -55,7 +54,6 @@
               <td class="mono">{{ $shop->id }}</td>
               <td><a href="{{ route('shops.edit', $shop->id) }}">{{ $shop->name }}</a></td>
               <td>{{ $shop->address }}</td>
-              <td class="mono">{{ $shop->prefecture_code ?? '-' }}</td>
               <td class="mono">{{ $shop->lat }}</td>
               <td class="mono">{{ $shop->lng }}</td>
               <td class="mono">{{ $shop->price ?? '-' }}</td>
@@ -72,7 +70,7 @@
             </tr>
           @empty
             <tr>
-              <td colspan="11" style="text-align:center; color:var(--muted); padding:24px;">データがありません</td>
+              <td colspan="10" style="text-align:center; color:var(--muted); padding:24px;">データがありません</td>
             </tr>
           @endforelse
         </tbody>


### PR DESCRIPTION
## Summary
- 店舗一覧・楽曲一覧のテーブルヘッダーがtbody上部に被らないようsticky指定を解除
- 店舗一覧から「都道府県」カラムを削除

## Validation
- `php artisan test`