### PR TITLE
ホーム画面の権限制御を追加

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
-})->middleware('auth');
+})->middleware(['auth', 'only10']);
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -16,6 +16,13 @@ class ExampleTest extends TestCase
             ->assertRedirect(route('login'));
     }
 
+    public function test_home_forbids_authenticated_users_without_permission(): void
+    {
+        $this->actingAs(User::factory()->create(['id' => (int) env('ALLOWED_USER_ID', 10) + 1]))
+            ->get('/')
+            ->assertForbidden();
+    }
+
     /**
      * A basic test example.
      */


### PR DESCRIPTION
## Summary
- ホーム `/` に `only10` ミドルウェアを追加し、許可ユーザー以外はログイン済みでも403にする
- 未ログイン時は引き続きログイン画面へリダイレクト
- ホームの権限制御テストを追加

## Validation
- `php artisan test`