### PR TITLE
403画面のHome導線を削除

### DIFF
--- a/resources/views/errors/403.blade.php
+++ b/resources/views/errors/403.blade.php
@@ -98,12 +98,6 @@
         @endauth
 
         <div class="row">
-          <a class="btn" href="{{ url('/') }}">
-            <!-- home -->
-            <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M3 21h18M5 21V8l7-5 7 5v13" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/><path d="M9 21v-6h6v6" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-            Homeへ戻る
-          </a>
-
           @guest
             <a class="btn primary" href="{{ route('login') }}">
               <!-- login -->
@@ -130,7 +124,7 @@
       </div>
 
       <footer>
-        © {{ date('Y') }} RB+ Rank Manager · <a class="link" href="{{ url('/') }}">Home</a>
+        © {{ date('Y') }} RB+ Rank Manager
       </footer>
     </div>
   </div>

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -20,7 +20,9 @@ class ExampleTest extends TestCase
     {
         $this->actingAs(User::factory()->create(['id' => (int) env('ALLOWED_USER_ID', 10) + 1]))
             ->get('/')
-            ->assertForbidden();
+            ->assertForbidden()
+            ->assertDontSee('Homeへ戻る')
+            ->assertDontSee('>Home<', false);
     }
 
     /**


### PR DESCRIPTION
## Summary
- 403画面からHomeへ戻るボタンを削除
- 403画面フッターのHomeリンクを削除
- 権限なしユーザーの403表示でHome導線が出ないことをテストで確認

## Validation
- `php artisan test`